### PR TITLE
Add key props to tooltip text for hotkeys

### DIFF
--- a/src/Lhasa.tsx
+++ b/src/Lhasa.tsx
@@ -882,7 +882,7 @@ export function LhasaComponent({
         let hotkey_arr = typeof hotkey === 'string' ? [hotkey] : hotkey;
         return (<div className='lhasa_tooltip_keybind_infoblock'>
           <b>Hotkeys:</b><br/><br/>
-          {hotkey_arr.map((hotkey_text) => <span className='lhasa_tooltip_keybind_info'>
+          {hotkey_arr.map((hotkey_text) => <span key={hotkey_text} className='lhasa_tooltip_keybind_info'>
             {hotkey_text}
           </span>)}
         </div>);


### PR DESCRIPTION
This update solves the following warning being displayed in the console when Lhasa mounts:
```
Warning: Each child in a list should have a unique "key" prop.
```