### PR TITLE
Fix tooltip delay

### DIFF
--- a/src/Lhasa.tsx
+++ b/src/Lhasa.tsx
@@ -30,7 +30,9 @@ function ToolButton(props:ToolButtonProps) {
       {context => (
         <Tooltip
           title={props.tooltip_body}
-          enterDelay={300}
+          enterDelay={1000}
+          enterNextDelay={1000}
+          disableInteractive
         >
           <ToggleButton
             selected={context.active_tool_name == props.action_name}


### PR DESCRIPTION
This update fixes the issue where the tooltips are shown too soon after the mouse hovers over the tool button:
- `enterDelay={1000}` increases the delay from 300ms to 1 second.
- `enterNextDelay={1000}` applies a 1 second delay before showing a tooltip when one was already being shown.
- `disableInteractive` means that the tooltip will hide immediately when mouse hovers over the tooltip, without waiting for `leaveDelay`. This ensures other tool buttons are not blocked by the tooltip.